### PR TITLE
Adding ability to send answer to dupservers asynchronously

### DIFF
--- a/configuration_parser.go
+++ b/configuration_parser.go
@@ -37,6 +37,7 @@ type configurationStruct struct {
 	loadLimit15              float64
 	showErrorOutput          bool
 	dupResultsArePassive     bool
+	sendDupResultsAsync      bool
 	gearmanConnectionTimeout int
 	restrictPath             []string
 	server                   []string
@@ -64,6 +65,7 @@ func setDefaultValues(result *configurationStruct) {
 	result.debug = 0
 	result.logmode = "automatic"
 	result.dupResultsArePassive = true
+	result.sendDupResultsAsync = false
 	result.gearmanConnectionTimeout = -1
 	result.timeoutReturn = 2
 	result.jobTimeout = 60
@@ -176,6 +178,8 @@ func readSetting(values []string, result *configurationStruct) {
 		result.showErrorOutput = getBool(value)
 	case "dup_results_are_passive":
 		result.dupResultsArePassive = getBool(value)
+	case "send_dup_results_async":
+		result.sendDupResultsAsync = getBool(value)
 	case "gearman_connection_timeout":
 		result.gearmanConnectionTimeout = getInt(value)
 	case "restrict_path":

--- a/configuration_parser.go
+++ b/configuration_parser.go
@@ -38,6 +38,7 @@ type configurationStruct struct {
 	showErrorOutput          bool
 	dupResultsArePassive     bool
 	sendDupResultsAsync      bool
+	maxNumberOfAsyncRequests int
 	gearmanConnectionTimeout int
 	restrictPath             []string
 	server                   []string
@@ -66,6 +67,7 @@ func setDefaultValues(result *configurationStruct) {
 	result.logmode = "automatic"
 	result.dupResultsArePassive = true
 	result.sendDupResultsAsync = false
+	result.maxNumberOfAsyncRequests = 1000
 	result.gearmanConnectionTimeout = -1
 	result.timeoutReturn = 2
 	result.jobTimeout = 60
@@ -180,6 +182,8 @@ func readSetting(values []string, result *configurationStruct) {
 		result.dupResultsArePassive = getBool(value)
 	case "send_dup_results_async":
 		result.sendDupResultsAsync = getBool(value)
+	case "max_number_of_async_requests":
+		result.maxNumberOfAsyncRequests = getInt(value)
 	case "gearman_connection_timeout":
 		result.gearmanConnectionTimeout = getInt(value)
 	case "restrict_path":

--- a/worker.go
+++ b/worker.go
@@ -149,7 +149,6 @@ func (worker *worker) doWork(job libworker.Job) (res []byte, err error) {
 		} else {
 			worker.SendResultDup(result)
 		}
-
 	}
 	return
 }

--- a/worker.go
+++ b/worker.go
@@ -155,8 +155,10 @@ func (worker *worker) doWork(job libworker.Job) (res []byte, err error) {
 		worker.SendResult(result)
 
 		if worker.config.sendDupResultsAsync {
-			if currentNumberOfInFlightAsyncRequests.value < 1000 {
+			if currentNumberOfInFlightAsyncRequests.value < worker.config.maxNumberOfAsyncRequests {
 				go worker.SendResultDup(result)
+			} else {
+				logger.Debugf("Not attempting SendResultDup because there are %i requests in flight vs maxNumberOfAsyncRequests: %i", currentNumberOfInFlightAsyncRequests.value, worker.config.maxNumberOfAsyncRequests)
 			}
 		} else {
 			worker.SendResultDup(result)

--- a/worker.go
+++ b/worker.go
@@ -144,7 +144,12 @@ func (worker *worker) doWork(job libworker.Job) (res []byte, err error) {
 	if received.resultQueue != "" {
 		logger.Tracef("result:\n%s", result)
 		worker.SendResult(result)
-		go worker.SendResultDup(result)
+		if worker.config.sendDupResultsAsync {
+			go worker.SendResultDup(result)
+		} else {
+			worker.SendResultDup(result)
+		}
+
 	}
 	return
 }

--- a/worker.go
+++ b/worker.go
@@ -144,7 +144,7 @@ func (worker *worker) doWork(job libworker.Job) (res []byte, err error) {
 	if received.resultQueue != "" {
 		logger.Tracef("result:\n%s", result)
 		worker.SendResult(result)
-		worker.SendResultDup(result)
+		go worker.SendResultDup(result)
 	}
 	return
 }


### PR DESCRIPTION
We use mod_gearman in a high-availability setup (i.e. one active and one passive) and use `dupserver` to submit the checkresults to the secondary server. We find that when the secondary server is unavailable, all the checks on the primary grind to a halt as it appears to be waiting for the secondary to respond. We've not been able to find a tunable connection timeout in the Gearman go client, however it seems that making the dupserver send asynchronous is possibly the best path to having this work as we intend. 

We've made it a configuration option, so that the default is unchanged; and users who are unable to accept invisible job losses can keep the default option.
For us, with `send_dup_results_async = yes` when we kill our secondaries off, the primary is essentially unaffected except for occasional flurries of logs for:
```
 failed to send back result (to dupserver): dial tcp 192.168.12.99:4730: connect: connection timed out
```

We were unable to find the example mod_gearman_worker configuration file to add a stub for this option in, so it's not included in this PR.