### PR TITLE
Fixing dupserver client/connection leak

### DIFF
--- a/dupserver.go
+++ b/dupserver.go
@@ -58,6 +58,7 @@ func runDupServerConsumer(dupServer dupServerConsumer) {
 			for {
 				client, error = sendResultDup(client, item, dupServer.address, dupServer.config)
 				if error != nil {
+					client.Close()
 					client = nil
 					logger.Debugf("failed to send back result (to dupserver): %s", error.Error())
 					select {

--- a/dupserver.go
+++ b/dupserver.go
@@ -58,7 +58,6 @@ func runDupServerConsumer(dupServer dupServerConsumer) {
 			for {
 				client, error = sendResultDup(client, item, dupServer.address, dupServer.config)
 				if error != nil {
-					client.Close()
 					client = nil
 					logger.Debugf("failed to send back result (to dupserver): %s", error.Error())
 					select {


### PR DESCRIPTION
Previously, the dupserver consumer was creating a new client/connection for every item it pushed to the dupserver itself; this is because the client wasn't getting set in `runDupServerConsumer` ever. We've now pulled the reference right the way through and it has resolved that problem.

This resulted in our secondaries no longer receiving updates etc after about 15-30 minutes of runtime :(

Secondly, when writing this; we have noticed that the error handling inside dupserver is different to https://github.com/ConSol/mod-gearman-worker-go/blob/master/worker.go#L182  however if we add client.Close() into the error handling it completely kills `mod-gearman-worker` when the dupserver has an error (https://github.com/ConSol/mod-gearman-worker-go/pull/15/commits/4ad4f4102eeb838e666d4e6df8df3ae589ffa339). Not sure how we're supposed to handle that situation better