### PR TITLE
Fixes #19

### DIFF
--- a/dupserver.go
+++ b/dupserver.go
@@ -88,7 +88,6 @@ func sendResultDup(client *client.Client, item *answer, dupAddress string, confi
 }
 
 func enqueueDupServerResult(config *configurationStruct, result *answer) {
-
 	duplicateResult := &answer{
 		hostName:           result.hostName,
 		serviceDescription: result.serviceDescription,

--- a/dupserver.go
+++ b/dupserver.go
@@ -88,10 +88,24 @@ func sendResultDup(client *client.Client, item *answer, dupAddress string, confi
 }
 
 func enqueueDupServerResult(config *configurationStruct, result *answer) {
+
+	duplicateResult := &answer{
+		hostName:           result.hostName,
+		serviceDescription: result.serviceDescription,
+		coreStartTime:      result.coreStartTime,
+		startTime:          result.startTime,
+		finishTime:         result.finishTime,
+		returnCode:         result.returnCode,
+		source:             result.source,
+		output:             result.output,
+		active:             result.active,
+		execType:           result.execType,
+	}
+
 	for _, dupAddress := range config.dupserver {
 		channel := dupServerConsumers[dupAddress].queue
 		select {
-		case channel <- result:
+		case channel <- duplicateResult:
 		default:
 			logger.Debugf("channel is at capacity (%d), dropping message (to dupserver): %s", config.dupServerBacklogQueueSize, dupAddress)
 		}

--- a/dupserver.go
+++ b/dupserver.go
@@ -88,24 +88,12 @@ func sendResultDup(client *client.Client, item *answer, dupAddress string, confi
 }
 
 func enqueueDupServerResult(config *configurationStruct, result *answer) {
-	duplicateResult := &answer{
-		hostName:           result.hostName,
-		serviceDescription: result.serviceDescription,
-		coreStartTime:      result.coreStartTime,
-		startTime:          result.startTime,
-		finishTime:         result.finishTime,
-		returnCode:         result.returnCode,
-		source:             result.source,
-		output:             result.output,
-		resultQueue:        result.resultQueue,
-		active:             result.active,
-		execType:           result.execType,
-	}
+	duplicateResult := *result
 
 	for _, dupAddress := range config.dupserver {
 		channel := dupServerConsumers[dupAddress].queue
 		select {
-		case channel <- duplicateResult:
+		case channel <- &duplicateResult:
 		default:
 			logger.Debugf("channel is at capacity (%d), dropping message (to dupserver): %s", config.dupServerBacklogQueueSize, dupAddress)
 		}

--- a/dupserver.go
+++ b/dupserver.go
@@ -98,6 +98,7 @@ func enqueueDupServerResult(config *configurationStruct, result *answer) {
 		returnCode:         result.returnCode,
 		source:             result.source,
 		output:             result.output,
+		resultQueue:        result.resultQueue,
 		active:             result.active,
 		execType:           result.execType,
 	}


### PR DESCRIPTION
Duplicating the Result object means that we have one for the normal result path and another copy for the dupserver path. 

Confirmed by building this our development environment and running it for 30 minutes without any Orphaned host checks or similiar (normally shows within 10 mins or so) and comparing against master@e908b77 (which does show the problem).

Previously there was a race condition between these two so that if `dupserver` is configured there was a chance that the passive "normal" results would be sent down the normal path. This results in mod_gearman not seeing the response as the right response for the active check that it submitted to the queue (presumably because it's now marked as passive).