### PR TITLE
Check nsc web environment variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 This file documents the revision history for the Mod-Gearman-Worker-Go
 
+Next     -------
+          - support passing environment variables to internal checks
+          - update internal check_nsc_web handler
+
 1.6.0    Fri Mar 27 10:26:20 CET 2026
           - fix crash on shutdown
           - add internal check_prometheus handler

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/appscode/g2 v0.0.0-20190123131438-388ba74fd273
-	github.com/consol-monitoring/check_nsc_web v0.7.4
+	github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260331160743-69b547f20a77
 	github.com/consol-monitoring/check_prometheus v0.0.0-20260211103550-7975b0b2fb41
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kdar/factorlog v0.0.0-20211012144011-6ea75a169038

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/appscode/g2 v0.0.0-20190123131438-388ba74fd273
-	github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260331160743-69b547f20a77
+	github.com/consol-monitoring/check_nsc_web v0.7.5
 	github.com/consol-monitoring/check_prometheus v0.0.0-20260211103550-7975b0b2fb41
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kdar/factorlog v0.0.0-20211012144011-6ea75a169038

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
-github.com/consol-monitoring/check_nsc_web v0.7.4 h1:EF9wO0NRmYuefSOkIB3c+oepqPRua+/cM4Znb5YQnhk=
-github.com/consol-monitoring/check_nsc_web v0.7.4/go.mod h1:erbc72XmMAiTK7IbZcclFBNjdEKB1xKVDk38dI4WR/k=
-github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260327092505-fe50a2fb0020 h1:r1jtNpoFVqcsY+4jekNVqS04nppleX4TuwMlY94B3dA=
-github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260327092505-fe50a2fb0020/go.mod h1:erbc72XmMAiTK7IbZcclFBNjdEKB1xKVDk38dI4WR/k=
-github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260331160743-69b547f20a77 h1:bm5D62mI0ZgRrOjbApvTiNCE2RSO0rGg0v0RkrpIlg0=
-github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260331160743-69b547f20a77/go.mod h1:erbc72XmMAiTK7IbZcclFBNjdEKB1xKVDk38dI4WR/k=
+github.com/consol-monitoring/check_nsc_web v0.7.5 h1:Fw7LgON8dAzADenDNDeWrVaarOTBka/PmAZD/UJeleM=
+github.com/consol-monitoring/check_nsc_web v0.7.5/go.mod h1:+CJERdSAKaQ2b5+zayinPRgny12VQYmUBcER8zquQgA=
 github.com/consol-monitoring/check_prometheus v0.0.0-20260211103550-7975b0b2fb41 h1:SBviw8FuSWWGNOShoJNJQu6ebxPtWkAN3rZhU+4sxu8=
 github.com/consol-monitoring/check_prometheus v0.0.0-20260211103550-7975b0b2fb41/go.mod h1:9N9L50PJGZXunjkeQF+GF2WODirKIPEBwbuFUg+iX/I=
 github.com/consol-monitoring/check_x v0.0.0-20260108170459-f7c19720a9ad h1:vf0rv/4E0dT4fc6A8H0hL/U9zUQBJPq2EXLEfwqc+yI=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcju
 github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/consol-monitoring/check_nsc_web v0.7.4 h1:EF9wO0NRmYuefSOkIB3c+oepqPRua+/cM4Znb5YQnhk=
 github.com/consol-monitoring/check_nsc_web v0.7.4/go.mod h1:erbc72XmMAiTK7IbZcclFBNjdEKB1xKVDk38dI4WR/k=
+github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260327092505-fe50a2fb0020 h1:r1jtNpoFVqcsY+4jekNVqS04nppleX4TuwMlY94B3dA=
+github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260327092505-fe50a2fb0020/go.mod h1:erbc72XmMAiTK7IbZcclFBNjdEKB1xKVDk38dI4WR/k=
+github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260331160743-69b547f20a77 h1:bm5D62mI0ZgRrOjbApvTiNCE2RSO0rGg0v0RkrpIlg0=
+github.com/consol-monitoring/check_nsc_web v0.7.5-0.20260331160743-69b547f20a77/go.mod h1:erbc72XmMAiTK7IbZcclFBNjdEKB1xKVDk38dI4WR/k=
 github.com/consol-monitoring/check_prometheus v0.0.0-20260211103550-7975b0b2fb41 h1:SBviw8FuSWWGNOShoJNJQu6ebxPtWkAN3rZhU+4sxu8=
 github.com/consol-monitoring/check_prometheus v0.0.0-20260211103550-7975b0b2fb41/go.mod h1:9N9L50PJGZXunjkeQF+GF2WODirKIPEBwbuFUg+iX/I=
 github.com/consol-monitoring/check_x v0.0.0-20260108170459-f7c19720a9ad h1:vf0rv/4E0dT4fc6A8H0hL/U9zUQBJPq2EXLEfwqc+yI=

--- a/pkg/modgearman/command.go
+++ b/pkg/modgearman/command.go
@@ -89,3 +89,12 @@ func (com *command) appendEnv(envs []string) {
 		com.Env[splitted[0]] = splitted[1]
 	}
 }
+
+// converts command environment to os.Environ() style, where they turn into an []string of <key>=<value>
+func (com *command) convertEnvToArray() []string {
+	env := make([]string, len(com.Env))
+	for key, value := range com.Env {
+		env = append(env, key+"="+value)
+	}
+	return env
+}

--- a/pkg/modgearman/command.go
+++ b/pkg/modgearman/command.go
@@ -92,9 +92,11 @@ func (com *command) appendEnv(envs []string) {
 
 // converts command environment to os.Environ() style, where they turn into an []string of <key>=<value>
 func (com *command) convertEnvToArray() []string {
-	env := make([]string, len(com.Env))
+	env := make([]string, 0, len(com.Env))
+
 	for key, value := range com.Env {
 		env = append(env, key+"="+value)
 	}
+
 	return env
 }

--- a/pkg/modgearman/command_test.go
+++ b/pkg/modgearman/command_test.go
@@ -89,7 +89,7 @@ func TestEnvironmentVariablesWithInternalChecks(t *testing.T) {
 		"check_drive_io " +
 		"warn=\"write_bytes_rate > 1Mb\" "
 	cmd := parseCommand(cmdLine, &cfg)
-	assert.Equal(t, CommandExecType(Internal), cmd.ExecType)
+	assert.Equal(t, Internal, cmd.ExecType)
 	assert.Equal(t, "/omd/sites/dev/lib/monitoring-plugins/check_nsc_web", cmd.Command)
 	assert.Equal(t, []string{
 		"-u",

--- a/pkg/modgearman/command_test.go
+++ b/pkg/modgearman/command_test.go
@@ -78,3 +78,26 @@ func TestCommandParser_BackslashSingle(t *testing.T) {
 	assert.Equal(t, []string{`\t\n`}, cmd.Args)
 	assert.Equal(t, map[string]string{}, cmd.Env)
 }
+
+func TestEnvironmentVariablesWithInternalChecks(t *testing.T) {
+	cfg := config{}
+	cfg.setDefaultValues()
+	cfg.internalCheckNscWeb = true
+	cmdLine := "check_nsc_web_password=hello " +
+		"/omd/sites/dev/lib/monitoring-plugins/check_nsc_web " +
+		"-u \"http://host.docker.internal:8443\" " +
+		"check_drive_io " +
+		"warn=\"write_bytes_rate > 1Mb\" "
+	cmd := parseCommand(cmdLine, &cfg)
+	assert.Equal(t, CommandExecType(Internal), cmd.ExecType)
+	assert.Equal(t, "/omd/sites/dev/lib/monitoring-plugins/check_nsc_web", cmd.Command)
+	assert.Equal(t, []string{
+		"-u",
+		"http://host.docker.internal:8443",
+		"check_drive_io",
+		"warn=write_bytes_rate > 1Mb",
+	}, cmd.Args)
+	assert.Equal(t, map[string]string{
+		"check_nsc_web_password": "hello",
+	}, cmd.Env)
+}

--- a/pkg/modgearman/internal_check_dummy.go
+++ b/pkg/modgearman/internal_check_dummy.go
@@ -9,7 +9,7 @@ import (
 
 type InternalCheckDummy struct{}
 
-func (chk *InternalCheckDummy) Check(_ context.Context, output *bytes.Buffer, args, env []string) (rc int) {
+func (chk *InternalCheckDummy) Check(_ context.Context, output *bytes.Buffer, args, _ []string) (rc int) {
 	if len(args) == 0 {
 		chk.printHelp(output)
 

--- a/pkg/modgearman/internal_check_dummy.go
+++ b/pkg/modgearman/internal_check_dummy.go
@@ -9,7 +9,7 @@ import (
 
 type InternalCheckDummy struct{}
 
-func (chk *InternalCheckDummy) Check(_ context.Context, output *bytes.Buffer, args []string) (rc int) {
+func (chk *InternalCheckDummy) Check(_ context.Context, output *bytes.Buffer, args, env []string) (rc int) {
 	if len(args) == 0 {
 		chk.printHelp(output)
 

--- a/pkg/modgearman/internal_check_nsc_web.go
+++ b/pkg/modgearman/internal_check_nsc_web.go
@@ -9,6 +9,6 @@ import (
 
 type InternalCheckNSCWeb struct{}
 
-func (chk *InternalCheckNSCWeb) Check(ctx context.Context, output *bytes.Buffer, args []string) int {
-	return checknscweb.Check(ctx, output, args)
+func (chk *InternalCheckNSCWeb) Check(ctx context.Context, output *bytes.Buffer, args, env []string) int {
+	return checknscweb.Check(ctx, output, args, env)
 }

--- a/pkg/modgearman/internal_check_prometheus.go
+++ b/pkg/modgearman/internal_check_prometheus.go
@@ -9,7 +9,7 @@ import (
 
 type internalCheckPrometheus struct{}
 
-func (chk *internalCheckPrometheus) Check(_ context.Context, output *bytes.Buffer, args, env []string) int {
+func (chk *internalCheckPrometheus) Check(_ context.Context, output *bytes.Buffer, args, _ []string) int {
 	// args passed to this function does not have the executable as first element.
 	// The cli parser library of check_prometheus however expects a program name
 	// Just like a normal argc , argv invocation

--- a/pkg/modgearman/internal_check_prometheus.go
+++ b/pkg/modgearman/internal_check_prometheus.go
@@ -9,7 +9,7 @@ import (
 
 type internalCheckPrometheus struct{}
 
-func (chk *internalCheckPrometheus) Check(_ context.Context, output *bytes.Buffer, args []string) int {
+func (chk *internalCheckPrometheus) Check(_ context.Context, output *bytes.Buffer, args, env []string) int {
 	// args passed to this function does not have the executable as first element.
 	// The cli parser library of check_prometheus however expects a program name
 	// Just like a normal argc , argv invocation

--- a/pkg/modgearman/internal_checks.go
+++ b/pkg/modgearman/internal_checks.go
@@ -8,7 +8,7 @@ import (
 )
 
 type InternalCheck interface {
-	Check(ctx context.Context, output *bytes.Buffer, args []string) int
+	Check(ctx context.Context, output *bytes.Buffer, args []string, env []string) int
 }
 
 func execInternal(result *answer, cmd *command, received *request) {
@@ -20,7 +20,7 @@ func execInternal(result *answer, cmd *command, received *request) {
 	go func() {
 		defer logPanicExit()
 		output := bytes.NewBuffer(nil)
-		rc := cmd.InternalCheck.Check(ctx, output, cmd.Args)
+		rc := cmd.InternalCheck.Check(ctx, output, cmd.Args, cmd.convertEnvToArray())
 		result.output = output.String()
 		result.returnCode = rc
 		cancel()

--- a/pkg/modgearman/mod_gearman_worker.go
+++ b/pkg/modgearman/mod_gearman_worker.go
@@ -471,6 +471,7 @@ Basic Settings:
        --config=<configfile>
        --server=<server>
        --dupserver=<server>
+	   -d / --daemon : Turns on the daemon mode. A second process will serve requests while the main process exits after starting it.
 
 Encryption:
        --encryption=<yes|no>


### PR DESCRIPTION
change the interface function for internal checks and add argument: env of type []string . when a gearman command is sent, the environment inside the command line was already parsed by the shelltoken library, but it was not being used for the internal checks

only the check_nsc_web currently utilizes this with this PR, check_prometheus and check_dummy does not utilize it downstream.

check_nsc_web is switched to a branch where environment can be passed as to its Check() function. it then looks for couple options to be passed.

tested with environment variable check_nsc_web_password on a OMD nagios system, it works to pass the password.

DO NOT merge, wait until check_nsc_web PR is approved. Then I will change the definition in go.mod to use master branch.